### PR TITLE
Corrected Mac path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tested on Cura 5.2.1
 To be used with the ringing_tower.stl as explained in https://marlinfw.org/docs/gcode/M593.html
 
 If you have a PC, place this python script in C:\USERS\\\<user name>\AppData\Roaming\cura\scripts
-or if you have a Mac, place it here /Users/\<user name>/Library/Application Scripts/cura/\<latest cura version>/scripts
+or if you have a Mac, place it here /Users/\<user name>/Library/Application Support/cura/\<latest cura version>/scripts
 
 then:
 


### PR DESCRIPTION
I'm using Cura 5.3.1 and the path suggested on `README.md` was not correct/didn't exist. The path that worked for me was inside `Application Support` instead of `Application Scripts`